### PR TITLE
Moving React to a peer dependency; allow React ^0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   },
   "homepage": "https://github.com/HurricaneJames/react-tinymce-input",
   "dependencies": {
-    "react": "^0.13.3",
     "uuid": "^2.0.1"
+  },
+  "peerDependencies": {
+    "react": "^0.13.3||^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
Browserified bundles with this module will include React twice for a bundle gain of 1.8mb (unminified); setting React as a peer dependency will avoid installing extra copies and simply warn or error the installation. Also, React is up to 0.14 now.
