### PR TITLE
fixes onblur being triggered twice

### DIFF
--- a/src/TinyMCEInput.js
+++ b/src/TinyMCEInput.js
@@ -231,7 +231,6 @@ var TinyMCEInput = React.createClass({
       // sync them now that we no longer have focus.
       tinyMCEEvent.target.setContent(this.state.value);
     }
-    if(this.props.onBlur) { this.props.onBlur(); }
   },
   onTinyMCEUndo: function(tinyMCEEvent) {
     this.triggerEventHandler(this.props.onUndo, tinyMCEEvent);


### PR DESCRIPTION
Hey! Thanks for your lib!

The blur event is being triggered twice, because your executing the handler function and calling the blur again. Hope this fixes it.