### PR TITLE
Move createReactClass and Proptypes as dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "homepage": "https://github.com/HurricaneJames/react-tinymce-input",
   "dependencies": {
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "create-react-class": "^15.6.0",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel": "^5.4.7",
@@ -32,18 +34,16 @@
     "babel-eslint": "^3.1.11",
     "babel-loader": "^5.1.3",
     "babel-runtime": "^5.5.4",
-    "create-react-class": "^15.6.0",
     "eslint": "^0.22.1",
     "eslint-plugin-react": "^2.5.0",
     "node-libs-browser": "^0.5.2",
     "react": "~15.6.1",
     "react-dom": "~15.6.1",
-    "prop-types": "^15.5.10",
     "react-hot-loader": "^1.3.1",
     "webpack": "^1.9.10",
     "webpack-dev-server": "^1.9.0"
   },
   "peerDependencies": {
-    "react": "^0.13 || ^0.14 || ^15.x"
+    "react": "^0.13 || ^0.14 || ^15.x || ^16.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "homepage": "https://github.com/HurricaneJames/react-tinymce-input",
   "dependencies": {
-    "uuid": "^2.0.1",
-    "create-react-class": "^15.6.0",
-    "prop-types": "^15.5.10"
+    "create-react-class": "^15.6.3",
+    "prop-types": "^15.6.1",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
New added packages are required for production build. They used to be part of peer React.

* Move required packages as dependencies
* Add npm config to disable package-lock
* Bump React peer version

Resolves: https://github.com/HurricaneJames/react-tinymce-input/issues/25